### PR TITLE
Updating Test action and removing preinstallation of ffmpeg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,28 @@ on:
       - "main"
 
 jobs:
-  build:
+  ubuntu-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [
+          12.x,
+          14.x
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: FedericoCarboni/setup-ffmpeg@v1-beta
+        id: setup-ffmpeg
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run test
+      - run: npm run build
+  windows-build:
+    runs-on: windows-latest
     strategy:
       matrix:
         node-version: [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,12 @@
 name: Testproject
 
 on: 
-  - push
-  - pull_request
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches: 
+      - "main"
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: FedericoCarboni/setup-ffmpeg@v1-beta
+        id: setup-ffmpeg
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,10 @@ async-ffmetadata is a module that gives you the possability to edit metadata for
 - [Alternative](#alternative)
 
 ## Getting Started
+
+### Prerequisit
+To run this nodemodule you need to install ffmpeg on you machine. It can be downloaded from here: [ffmpeg Download](https://ffmpeg.org/download.html)
+
 ### Install
 ```console
 npm i async-ffmetadata

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ import { exec } from 'child_process'
 import { metadataObj } from './interfaces'
 import * as path from 'path'
 
-const dirname = path.dirname(__filename)
-const ffmpegDefaultPath = path.join(dirname, '../data/ffmpeg.exe');
 
 /**
  * Returning string of a command from the given params
@@ -34,7 +32,7 @@ export function getExecString(command: string, attr: {name?:string, value?:strin
  * @returns {object} Return an object with metadata in the format {<metadataname>:<metadatavalue>}
  */
 export async function getMetaDataFromFile(filePath:string, options?: {customFfmpegPath: string}): Promise<metadataObj> {
-  const ffmpegPath = options?.customFfmpegPath || ffmpegDefaultPath
+  const ffmpegPath = options?.customFfmpegPath || "ffmpeg"
   const command = getExecString(ffmpegPath, [
     {
       name: "i",
@@ -85,7 +83,7 @@ export async function getMetaDataFromFile(filePath:string, options?: {customFfmp
  * @returns {boolean} gives back if it was successfull with writing the metadata
  */
 export async function setMetaDataToFile(metaData: metadataObj, inFilePath: string, outFilePath: string, options?: {customFfmpegPath: string}): Promise<boolean> {
-  const ffmpegPath = options?.customFfmpegPath || ffmpegDefaultPath
+  const ffmpegPath = options?.customFfmpegPath || "ffmpeg"
   // Creates the attr array for getExecString function with the metaData
   function getCommand() {
     let commandArray = [

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -4,21 +4,6 @@ import * as ffmetadata from '../index'
 import * as path from 'path'
 import * as fs from "fs"
 
-/**
- * Creating the testfile with metadata
- */
-before(async () => {
-  const pathToInFile = path.join(__dirname, 'test.mp3')
-  const pathToOutFile = path.join(__dirname, '_test.mp3')
-  const metaData = {
-    albumArtist: 'AlbumInterpret',
-    encoder: 'Lavf58.45.100',
-    title: 'TestTitle',
-    track: '1'
-  }
-  await setMetaDataToFile(metaData, pathToInFile, pathToOutFile)
-})
-
 describe('getExecString: ', () => {
   it('Basic Functionality', () => {
     const result = getExecString('testcom', [
@@ -73,10 +58,7 @@ describe('getExecString: ', () => {
 
 describe('getMetaDataFromFile', () => {
   it('Basic Functionality - Should return Object with Metadata', async () => {
-    const pathToFile = path.join(__dirname, '_test.mp3')
-    const pathExists = fs.existsSync(pathToFile)
-    console.log('pathToFile: ', pathToFile);
-    console.log('pathExists: ', pathExists);
+    const pathToFile = path.join(__dirname, 'test.mp3')
 
     const result = await getMetaDataFromFile(pathToFile)
     const expected = {
@@ -89,7 +71,7 @@ describe('getMetaDataFromFile', () => {
     assert.deepStrictEqual(expected, result)
   })
   it('Diffrent Import - Should return Object with Metadata D', async () => {
-    const pathToFile = path.join(__dirname, '_test.mp3')
+    const pathToFile = path.join(__dirname, 'test.mp3')
 
     const result = await ffmetadata.getMetaDataFromFile(pathToFile)
     const expected = {
@@ -121,7 +103,7 @@ describe('getMetaDataFromFile', () => {
 
 describe('setMetaDataToFile', () => {
   it('Basic Functionlity - Should return true', async () => {
-    const pathToFile = path.join(__dirname, '_test.mp3')
+    const pathToFile = path.join(__dirname, 'test.mp3')
     const pathToSaveFile = path.join(__dirname, '__test.mp3')
 
     const result = await setMetaDataToFile({
@@ -156,7 +138,7 @@ describe('setMetaDataToFile', () => {
     assert.strictEqual(expected, result)
   })
   it('Input same as Output - Should return false', async () => {
-    const pathToFile = path.join(__dirname, '_test.mp3')
+    const pathToFile = path.join(__dirname, 'test.mp3')
 
     const result = await setMetaDataToFile({
       album: 'Test Album'
@@ -165,12 +147,4 @@ describe('setMetaDataToFile', () => {
 
     assert.strictEqual(expected, result)
   })
-})
-
-/**
- * Removing the testfile with metadata
- */
-after(() => {
-  const pathToOutFile = path.join(__dirname, '_test.mp3')
-  fs.unlinkSync(pathToOutFile)
 })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -4,6 +4,21 @@ import * as ffmetadata from '../index'
 import * as path from 'path'
 import * as fs from "fs"
 
+/**
+ * Creating the testfile with metadata
+ */
+before(async () => {
+  const pathToInFile = path.join(__dirname, 'test.mp3')
+  const pathToOutFile = path.join(__dirname, '_test.mp3')
+  const metaData = {
+    albumArtist: 'AlbumInterpret',
+    encoder: 'Lavf58.45.100',
+    title: 'TestTitle',
+    track: '1'
+  }
+  await setMetaDataToFile(metaData, pathToInFile, pathToOutFile)
+})
+
 describe('getExecString: ', () => {
   it('Basic Functionality', () => {
     const result = getExecString('testcom', [
@@ -58,7 +73,7 @@ describe('getExecString: ', () => {
 
 describe('getMetaDataFromFile', () => {
   it('Basic Functionality - Should return Object with Metadata', async () => {
-    const pathToFile = path.join(__dirname, 'test.mp3')
+    const pathToFile = path.join(__dirname, '_test.mp3')
     const pathExists = fs.existsSync(pathToFile)
     console.log('pathToFile: ', pathToFile);
     console.log('pathExists: ', pathExists);
@@ -74,7 +89,7 @@ describe('getMetaDataFromFile', () => {
     assert.deepStrictEqual(expected, result)
   })
   it('Diffrent Import - Should return Object with Metadata D', async () => {
-    const pathToFile = path.join(__dirname, 'test.mp3')
+    const pathToFile = path.join(__dirname, '_test.mp3')
 
     const result = await ffmetadata.getMetaDataFromFile(pathToFile)
     const expected = {
@@ -106,7 +121,7 @@ describe('getMetaDataFromFile', () => {
 
 describe('setMetaDataToFile', () => {
   it('Basic Functionlity - Should return true', async () => {
-    const pathToFile = path.join(__dirname, 'test.mp3')
+    const pathToFile = path.join(__dirname, '_test.mp3')
     const pathToSaveFile = path.join(__dirname, '__test.mp3')
 
     const result = await setMetaDataToFile({
@@ -141,7 +156,7 @@ describe('setMetaDataToFile', () => {
     assert.strictEqual(expected, result)
   })
   it('Input same as Output - Should return false', async () => {
-    const pathToFile = path.join(__dirname, 'test.mp3')
+    const pathToFile = path.join(__dirname, '_test.mp3')
 
     const result = await setMetaDataToFile({
       album: 'Test Album'
@@ -150,4 +165,12 @@ describe('setMetaDataToFile', () => {
 
     assert.strictEqual(expected, result)
   })
+})
+
+/**
+ * Removing the testfile with metadata
+ */
+after(() => {
+  const pathToOutFile = path.join(__dirname, '_test.mp3')
+  fs.unlinkSync(pathToOutFile)
 })


### PR DESCRIPTION
The Test workflow now works.
Action now only runs on pushes or pullrequests to main.
ffmpeg is now required before the useage of this module.